### PR TITLE
Add Universal Action and File Action

### DIFF
--- a/FSNotes/info.plist
+++ b/FSNotes/info.plist
@@ -8,11 +8,11 @@
 	<string>Productivity</string>
 	<key>connections</key>
 	<dict>
-		<key>4CCAADAB-A681-45A8-A2EB-999EBE0FC3D6</key>
+		<key>23B67ECD-1869-4914-8F53-E5C6E1E67D4D</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>7AA09613-A1D7-4057-A5C1-6D57C7300FB2</string>
+				<string>7F4374FA-09BB-4356-8EDF-F14DC2E3F4BD</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -21,11 +21,24 @@
 				<false/>
 			</dict>
 		</array>
-		<key>5B7FFFA8-99FA-4F78-98D7-3675E4DE095B</key>
+		<key>45CB2A3E-7B07-4E8A-A702-9CB9EB8FDCD0</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>46D37702-C3E3-4E6D-B67F-A575E6E60569</string>
+				<string>4CCAADAB-A681-45A8-A2EB-999EBE0FC3D6</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>4CCAADAB-A681-45A8-A2EB-999EBE0FC3D6</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>7AA09613-A1D7-4057-A5C1-6D57C7300FB2</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -40,7 +53,20 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>C5C6A542-40FF-4540-AB41-594EC95C33C6</string>
+				<string>46D37702-C3E3-4E6D-B67F-A575E6E60569</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>7F4374FA-09BB-4356-8EDF-F14DC2E3F4BD</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>45CB2A3E-7B07-4E8A-A702-9CB9EB8FDCD0</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -62,19 +88,6 @@
 				<false/>
 			</dict>
 		</array>
-		<key>9BADE04B-E691-43B0-ACA1-63DFF887A131</key>
-		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>5B7FFFA8-99FA-4F78-98D7-3675E4DE095B</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-		</array>
 		<key>C3B33938-9067-40CA-AE28-41D23F563D6D</key>
 		<array>
 			<dict>
@@ -88,11 +101,11 @@
 				<false/>
 			</dict>
 		</array>
-		<key>C5C6A542-40FF-4540-AB41-594EC95C33C6</key>
+		<key>D2178BD0-31DA-4291-BB6D-71FE0C8CABA6</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>9BADE04B-E691-43B0-ACA1-63DFF887A131</string>
+				<string>5FADA805-B74A-41BF-8350-297178DDF691</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -101,11 +114,11 @@
 				<false/>
 			</dict>
 		</array>
-		<key>D2178BD0-31DA-4291-BB6D-71FE0C8CABA6</key>
+		<key>D358A830-E5DD-4CE7-996D-F52D2B22E17F</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>5FADA805-B74A-41BF-8350-297178DDF691</string>
+				<string>6B4A2BEA-94F4-4221-BF29-361A2A966FF9</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -225,6 +238,27 @@
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>skipqueryencode</key>
+				<false/>
+				<key>skipvarencode</key>
+				<false/>
+				<key>spaces</key>
+				<string>%20</string>
+				<key>url</key>
+				<string>fsnotes://find/{query}</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>E6CA6A6C-4011-43B6-9376-007BD4C6C826</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>anchorfields</key>
 				<true/>
 				<key>argumenttrimmode</key>
@@ -324,23 +358,17 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
+				<key>openwith</key>
+				<string>/Applications/FSNotes.app</string>
+				<key>sourcefile</key>
 				<string></string>
-				<key>skipqueryencode</key>
-				<false/>
-				<key>skipvarencode</key>
-				<false/>
-				<key>spaces</key>
-				<string>%20</string>
-				<key>url</key>
-				<string>fsnotes://find/{query}</string>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
+			<string>alfred.workflow.action.openfile</string>
 			<key>uid</key>
-			<string>E6CA6A6C-4011-43B6-9376-007BD4C6C826</string>
+			<string>6B4A2BEA-94F4-4221-BF29-361A2A966FF9</string>
 			<key>version</key>
-			<integer>1</integer>
+			<integer>3</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -441,17 +469,25 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>openwith</key>
-				<string>/Applications/FSNotes.app</string>
-				<key>sourcefile</key>
-				<string></string>
+				<key>acceptsmulti</key>
+				<integer>0</integer>
+				<key>filetypes</key>
+				<array>
+					<string>es.fsnot.etp.package</string>
+					<string>net.daringfireball.markdown</string>
+					<string>org.textbundle.compressed</string>
+					<string>org.textbundle.package</string>
+					<string>public.rtf</string>
+				</array>
+				<key>name</key>
+				<string>Import to FSNotes</string>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.action.openfile</string>
+			<string>alfred.workflow.trigger.action</string>
 			<key>uid</key>
-			<string>6B4A2BEA-94F4-4221-BF29-361A2A966FF9</string>
+			<string>D358A830-E5DD-4CE7-996D-F52D2B22E17F</string>
 			<key>version</key>
-			<integer>3</integer>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -498,57 +534,16 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>concurrently</key>
-				<false/>
-				<key>escaping</key>
-				<integer>102</integer>
-				<key>script</key>
-				<string>pbpaste</string>
-				<key>scriptargtype</key>
-				<integer>1</integer>
-				<key>scriptfile</key>
+				<key>argument</key>
 				<string></string>
-				<key>type</key>
-				<integer>5</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>C5C6A542-40FF-4540-AB41-594EC95C33C6</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argument</key>
-				<string>{query}</string>
-				<key>passthroughargument</key>
-				<false/>
-				<key>variables</key>
-				<dict>
-					<key>txt</key>
-					<string>{query}</string>
-				</dict>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.argument</string>
-			<key>uid</key>
-			<string>5B7FFFA8-99FA-4F78-98D7-3675E4DE095B</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argument</key>
-				<string>{query}</string>
 				<key>passthroughargument</key>
 				<false/>
 				<key>variables</key>
 				<dict>
 					<key>title</key>
 					<string>{query}</string>
+					<key>txt</key>
+					<string>{clipboard}</string>
 				</dict>
 			</dict>
 			<key>type</key>
@@ -561,17 +556,57 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>argument</key>
-				<string>'{query}', {variables}</string>
-				<key>cleardebuggertext</key>
+				<key>acceptsfiles</key>
 				<false/>
-				<key>processoutputs</key>
+				<key>acceptsmulti</key>
+				<integer>0</integer>
+				<key>acceptstext</key>
 				<true/>
+				<key>acceptsurls</key>
+				<true/>
+				<key>name</key>
+				<string>Add to FSNotes…</string>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.utility.debug</string>
+			<string>alfred.workflow.trigger.universalaction</string>
 			<key>uid</key>
-			<string>9BADE04B-E691-43B0-ACA1-63DFF887A131</string>
+			<string>23B67ECD-1869-4914-8F53-E5C6E1E67D4D</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<false/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>7F4374FA-09BB-4356-8EDF-F14DC2E3F4BD</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string></string>
+				<key>passthroughargument</key>
+				<false/>
+				<key>variables</key>
+				<dict/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>45CB2A3E-7B07-4E8A-A702-9CB9EB8FDCD0</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -588,6 +623,8 @@ This workflow offers the following triggers:
 * `fsc` — Create new note from Clipboard with optional title
 * `fsf` — Search notes as files
 * `fsi` — File filter to add a selected
+* Universal Action to import text selected or from Clipboard History
+* File Action to add a file
 
 
 ## Documentation
@@ -600,14 +637,32 @@ https://github.com/gingerbeardman/fsnotes-alfred-workflow</string>
 			<key>xpos</key>
 			<real>490</real>
 			<key>ypos</key>
-			<real>50</real>
+			<real>30</real>
+		</dict>
+		<key>23B67ECD-1869-4914-8F53-E5C6E1E67D4D</key>
+		<dict>
+			<key>note</key>
+			<string>New note from selected text or Clipboard History</string>
+			<key>xpos</key>
+			<real>225</real>
+			<key>ypos</key>
+			<real>950</real>
+		</dict>
+		<key>45CB2A3E-7B07-4E8A-A702-9CB9EB8FDCD0</key>
+		<dict>
+			<key>note</key>
+			<string>Empty argument so it does not populate keyword</string>
+			<key>xpos</key>
+			<real>610</real>
+			<key>ypos</key>
+			<real>980</real>
 		</dict>
 		<key>46D37702-C3E3-4E6D-B67F-A575E6E60569</key>
 		<dict>
 			<key>xpos</key>
-			<real>790</real>
+			<real>490</real>
 			<key>ypos</key>
-			<real>640</real>
+			<real>765</real>
 		</dict>
 		<key>4CCAADAB-A681-45A8-A2EB-999EBE0FC3D6</key>
 		<dict>
@@ -616,35 +671,37 @@ https://github.com/gingerbeardman/fsnotes-alfred-workflow</string>
 			<key>xpos</key>
 			<real>225</real>
 			<key>ypos</key>
-			<real>615</real>
-		</dict>
-		<key>5B7FFFA8-99FA-4F78-98D7-3675E4DE095B</key>
-		<dict>
-			<key>xpos</key>
-			<real>715</real>
-			<key>ypos</key>
-			<real>670</real>
+			<real>765</real>
 		</dict>
 		<key>5FADA805-B74A-41BF-8350-297178DDF691</key>
 		<dict>
 			<key>xpos</key>
 			<real>490</real>
 			<key>ypos</key>
-			<real>195</real>
+			<real>175</real>
 		</dict>
 		<key>6B4A2BEA-94F4-4221-BF29-361A2A966FF9</key>
 		<dict>
 			<key>xpos</key>
 			<real>490</real>
 			<key>ypos</key>
-			<real>495</real>
+			<real>475</real>
 		</dict>
 		<key>7AA09613-A1D7-4057-A5C1-6D57C7300FB2</key>
 		<dict>
 			<key>xpos</key>
-			<real>445</real>
+			<real>400</real>
 			<key>ypos</key>
-			<real>670</real>
+			<real>795</real>
+		</dict>
+		<key>7F4374FA-09BB-4356-8EDF-F14DC2E3F4BD</key>
+		<dict>
+			<key>note</key>
+			<string>Make text into most recent clipboard entry</string>
+			<key>xpos</key>
+			<real>405</real>
+			<key>ypos</key>
+			<real>950</real>
 		</dict>
 		<key>8991B972-F0E9-404C-9C4F-ADAB9F89C597</key>
 		<dict>
@@ -655,13 +712,6 @@ https://github.com/gingerbeardman/fsnotes-alfred-workflow</string>
 			<key>ypos</key>
 			<real>475</real>
 		</dict>
-		<key>9BADE04B-E691-43B0-ACA1-63DFF887A131</key>
-		<dict>
-			<key>xpos</key>
-			<real>635</real>
-			<key>ypos</key>
-			<real>670</real>
-		</dict>
 		<key>C3B33938-9067-40CA-AE28-41D23F563D6D</key>
 		<dict>
 			<key>note</key>
@@ -670,13 +720,6 @@ https://github.com/gingerbeardman/fsnotes-alfred-workflow</string>
 			<real>220</real>
 			<key>ypos</key>
 			<real>30</real>
-		</dict>
-		<key>C5C6A542-40FF-4540-AB41-594EC95C33C6</key>
-		<dict>
-			<key>xpos</key>
-			<real>495</real>
-			<key>ypos</key>
-			<real>640</real>
 		</dict>
 		<key>D2178BD0-31DA-4291-BB6D-71FE0C8CABA6</key>
 		<dict>
@@ -687,12 +730,21 @@ https://github.com/gingerbeardman/fsnotes-alfred-workflow</string>
 			<key>ypos</key>
 			<real>175</real>
 		</dict>
+		<key>D358A830-E5DD-4CE7-996D-F52D2B22E17F</key>
+		<dict>
+			<key>note</key>
+			<string>Import note</string>
+			<key>xpos</key>
+			<real>225</real>
+			<key>ypos</key>
+			<real>620</real>
+		</dict>
 		<key>E6CA6A6C-4011-43B6-9376-007BD4C6C826</key>
 		<dict>
 			<key>xpos</key>
 			<real>490</real>
 			<key>ypos</key>
-			<real>340</real>
+			<real>320</real>
 		</dict>
 		<key>EF1F8326-75C4-481B-9ECE-CAE81C096C4B</key>
 		<dict>
@@ -706,10 +758,8 @@ https://github.com/gingerbeardman/fsnotes-alfred-workflow</string>
 	</dict>
 	<key>userconfigurationconfig</key>
 	<array/>
-	<key>variablesdontexport</key>
-	<array/>
 	<key>version</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>webaddress</key>
 	<string>http://www.gingerbeardman.com</string>
 </dict>


### PR DESCRIPTION
[As suggested](https://www.alfredforum.com/topic/19551-fsnotes/#comment-101938), adds:

* Universal Action to import text selected or from Clipboard History.
* File Action to add a file.

Also bumps version to 2.4 and simplifies the `fsc` case (no need for the Run Script, one can simply use [`{clipboard}`](https://www.alfredapp.com/help/workflows/advanced/placeholders/#clipboard).

[⤓ Packaged Workflow for easier review](https://github.com/gingerbeardman/fsnotes-alfred-workflow/files/10452664/FSNotes.alfredworkflow.zip)

![fa](https://user-images.githubusercontent.com/1699443/213339656-88d1aa17-01e4-41d6-b4e1-6870341e91e8.png)
![ua](https://user-images.githubusercontent.com/1699443/213339658-684299eb-747a-4624-aa0a-d4fcb96f40f5.png)
